### PR TITLE
Applying padding to sampler functions

### DIFF
--- a/src/compressor/sampler.c
+++ b/src/compressor/sampler.c
@@ -1,18 +1,50 @@
 #include "sampler.h"
 
+// Calcula o padding necessário para uma dimensão do canal com downsample aplicado
+int calculateSample420Padding(int dimension, int blkSize) {
+    int sampledDim = dimension / 2;
+
+    if(sampledDim % 8 != 0)
+        return 8 - (sampledDim % 8);
+    return 0;
+}
+/*
+int calculateSamplePadding(DBMATRIX *channel, int *pdHeigth, int *pdWidth) {
+    int newHeigth = channel->lines / 2;
+    int newWidth = channel->cols / 2;
+
+    printf("nH: %d\n", newHeigth);
+
+    // Padding para a altura alcançar o próximo múltiplo de 8
+    if(newHeigth % 8 != 0)
+        *pdHeigth = 8 - (newHeigth % 8);
+    else
+        *pdHeigth = 0;
+
+    // Padding para a largura alcançar o próximo múltiplo de 8
+    if(newWidth % 8 != 0)
+        *pdWidth = 8 - (newWidth % 8);
+    else
+        *pdWidth = 0;
+}
+*/
+
 // Aplica a subamostragem 4:2:0 na matrix yCbCr por meio
 // Da média dos valores em um bloco 2 x 2
-DBMATRIX downSample420(DBMATRIX *channel) {
+DBMATRIX downSample420(DBMATRIX *channel, int blkSize) {
     DBMATRIX compressed;
     double average;
     int heigth = channel->lines;
     int width = channel->cols;
 
-    // Instanciando a nova matriz dos dados subamostrados
-    compressed = dbMatrixCreate((int) (heigth / 2), (int) (width / 2));
+    // Calculando o padding, quando necessário
+    int pdH = calculateSample420Padding(channel->lines, blkSize);
+    int pdW = calculateSample420Padding(channel->cols, blkSize);
 
-    // Andando pelos blocos 2x2 e substituindo pela média da
-    // croominância
+    // Instanciando a nova matriz dos dados subamostrados
+    compressed = dbMatrixCreate((heigth / 2) + pdH, (width / 2) + pdW);
+
+    // Andando pelos blocos 2x2 e substituindo pela média da croominância
     for(int i = 0; i < heigth; i += 2) {
         for(int j = 0; j < width; j += 2) {
             average = (channel->matrix[i][j] + channel->matrix[i][j+1] + 
@@ -27,12 +59,12 @@ DBMATRIX downSample420(DBMATRIX *channel) {
 
 // Recria a matriz original a partir de um canal subamostrado
 // Em 4:2:0
-DBMATRIX upSample420(DBMATRIX *sampledData) {
+DBMATRIX upSample420(DBMATRIX *sampledData, int pdHeigth, int pdWidth) {
     DBMATRIX decData;
 
     // Instanciando a matriz do tamanho da matrix original
-    int width = sampledData->cols * 2;
-    int heigth = sampledData->lines * 2;
+    int width = (sampledData->cols - pdWidth) * 2;
+    int heigth = (sampledData->lines - pdHeigth) * 2;
     decData = dbMatrixCreate(heigth, width);
 
     // Iterando pela nova matriz e copiando os valores perdidos

--- a/src/compressor/sampler.h
+++ b/src/compressor/sampler.h
@@ -9,8 +9,9 @@
 
     // Funções para aplicar subamostragem na etapa de tratamento
     // das imagens
-    DBMATRIX downSample420(DBMATRIX *channel);
-    DBMATRIX upSample420(DBMATRIX *sampledData);
+    int calculateSample420Padding(int dimension, int blkSize);
+    DBMATRIX downSample420(DBMATRIX *channel, int blkSize);
+    DBMATRIX upSample420(DBMATRIX *sampledData, int pdHeigth, int pdWidth);
 
 
 #endif

--- a/src/fileManager/fileManager.c
+++ b/src/fileManager/fileManager.c
@@ -102,9 +102,15 @@ bool compress(BMP *bmp) {
 
     bmpGetYcbcrChannels(bmp, &channelY, &channelCb, &channelCr);
 
-    // Downsampling each channel
-    DBMATRIX spChannelCb = downSample420(&channelCb);
-    DBMATRIX spChannelCr = downSample420(&channelCr);
+    // Calculando o padding dos canais
+    int pdCbH = calculateSample420Padding(channelCb.lines, BLK_SIZE);
+    int pdCbW = calculateSample420Padding(channelCb.cols, BLK_SIZE);
+    int pdCrH = calculateSample420Padding(channelCr.lines, BLK_SIZE);
+    int pdCrW = calculateSample420Padding(channelCr.cols, BLK_SIZE);
+
+    // Downsampling de cada canal
+    DBMATRIX spChannelCb = downSample420(&channelCb, BLK_SIZE);
+    DBMATRIX spChannelCr = downSample420(&channelCr, BLK_SIZE);
     dbMatrixDestroy(&channelCb);
     dbMatrixDestroy(&channelCr);
 
@@ -120,6 +126,7 @@ bool compress(BMP *bmp) {
         dbMatrixGetBlock(&channelY, BLK_SIZE, i, block);
         dct(BLK_SIZE, block, true);
     }
+
     return false;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -23,7 +23,16 @@ int main() {
     char *bmp4 = "img/colors.bmp";
     char *testFile = "test.bmp";
 
-    testBitBuffer();
+    testDctImage(bmp1, testFile);
 
+    /*
+    DBMATRIX test = dbMatrixCreate(10, 16);
+    int pdH = calculateSample420Padding(test.lines, 8);
+    int pdW  = calculateSample420Padding(test.cols, 8);
+
+    printf("(H: %d, W:%d)\n", pdH, pdW);
+
+    dbMatrixDestroy(&test);
+    */
     return 0;
 }

--- a/src/test/compressTest.c
+++ b/src/test/compressTest.c
@@ -54,15 +54,20 @@ void testSampler(char *bmpEntry, char *bmpExit) {
     DBMATRIX channelCr = dbMatrixCreate(heigth, width);
     bmpGetYcbcrChannels(bmp, &channelY, &channelCb, &channelCr);
 
+    // Calculando o padding dos canais
+    int pdCbH = calculateSample420Padding(channelCb.lines, 8);
+    int pdCbW = calculateSample420Padding(channelCb.cols, 8);
+    int pdCrH = calculateSample420Padding(channelCr.lines, 8);
+    int pdCrW = calculateSample420Padding(channelCr.cols, 8);
 
     // Aplicando e revertendo o downsampling
-    DBMATRIX spCb = downSample420(&channelCb);
-    DBMATRIX spCr = downSample420(&channelCr);
+    DBMATRIX spCb = downSample420(&channelCb, 8);
+    DBMATRIX spCr = downSample420(&channelCr, 8);
     dbMatrixDestroy(&channelCb);
     dbMatrixDestroy(&channelCr);
     
-    DBMATRIX newCb = upSample420(&spCb);
-    DBMATRIX newCr = upSample420(&spCr);
+    DBMATRIX newCb = upSample420(&spCb, pdCbH, pdCbW);
+    DBMATRIX newCr = upSample420(&spCr, pdCrH, pdCrW);
     dbMatrixDestroy(&spCb);
     dbMatrixDestroy(&spCr);
 
@@ -129,6 +134,7 @@ void testDct() {
     return;
 }
 
+
 // Executa toda a compressão com perda e faz a volta,
 // recriando a imagem original
 void testDctImage(char *bmpEntry, char *bmpExit) {
@@ -145,9 +151,15 @@ void testDctImage(char *bmpEntry, char *bmpExit) {
     DBMATRIX channelCr = dbMatrixCreate(heigth, width);
     bmpGetYcbcrChannels(bmp, &channelY, &channelCb, &channelCr);
 
+    // Calculando o padding dos canais
+    int pdCbH = calculateSample420Padding(channelCb.lines, 8);
+    int pdCbW = calculateSample420Padding(channelCb.cols, 8);
+    int pdCrH = calculateSample420Padding(channelCr.lines, 8);
+    int pdCrW = calculateSample420Padding(channelCr.cols, 8);
+
     // Aplicando o downsampling
-    DBMATRIX spCb = downSample420(&channelCb);
-    DBMATRIX spCr = downSample420(&channelCr);
+    DBMATRIX spCb = downSample420(&channelCb, 8);
+    DBMATRIX spCr = downSample420(&channelCr, 8);
     dbMatrixDestroy(&channelCb);
     dbMatrixDestroy(&channelCr);
     
@@ -167,8 +179,6 @@ void testDctImage(char *bmpEntry, char *bmpExit) {
         dct(BLK_SIZE, block, true);
         quantize(BLK_SIZE, block, auxBlock, LUM_QNT_TBL);
 
-
-
         dequantize(BLK_SIZE, auxBlock, block, LUM_QNT_TBL);
         inverseDct(BLK_SIZE, block, true);
         dbMatrixSetBlock(&channelY, BLK_SIZE, i, block);
@@ -178,20 +188,9 @@ void testDctImage(char *bmpEntry, char *bmpExit) {
         double block[8][8];
         int auxBlock[8][8];
 
-        printf("%d\n", i);
-        printf("1\n");
-
         dbMatrixGetBlock(&spCb, BLK_SIZE, i, block);
-        
-        printf("2\n");
-
         dct(BLK_SIZE, block, true);
-
-        printf("3\n");
-
         quantize(BLK_SIZE, block, auxBlock, CROM_QNT_TBL);
-
-        printf("4\n\n");
 
         dequantize(BLK_SIZE, auxBlock, block, CROM_QNT_TBL);
         inverseDct(BLK_SIZE, block, true);
@@ -212,8 +211,8 @@ void testDctImage(char *bmpEntry, char *bmpExit) {
     }
 
     // Revertendo o downsampling 
-    DBMATRIX newCb = upSample420(&spCb);
-    DBMATRIX newCr = upSample420(&spCr);
+    DBMATRIX newCb = upSample420(&spCb, pdCbH, pdCbW);
+    DBMATRIX newCr = upSample420(&spCr, pdCrH, pdCrW);
     dbMatrixDestroy(&spCb);
     dbMatrixDestroy(&spCr);
 


### PR DESCRIPTION
Precisavamos corrigir o TAD sampler para adcionar um padding que trata-se imagens cujo downsample dos canais cb e cr não fosse multiplo de 8